### PR TITLE
Fix OpenVPN import issue

### DIFF
--- a/htb/__main__.py
+++ b/htb/__main__.py
@@ -912,6 +912,7 @@ class HackTheBox(Cmd):
         with tempfile.NamedTemporaryFile() as ovpn:
             # Write the configuration to a file
             ovpn.write(self.cnxn.lab.config)
+            ovpn.flush()
 
             # Import the connection w/ Network Manager CLI
             p = subprocess.run(


### PR DESCRIPTION
Previously, the command `htb lab import` would fail.  This is because it
was writing an empty file, as the write() would be buffered and not
flush to file before the `nmcli` import was called.

This change explicitly calls flush() to commit the changes to the file,
meaning the contents is written to the file.

Fixes: calebstewart/python-htb#6
Signed-off-by: Dave Walker (Daviey) <email@daviey.com>